### PR TITLE
Remove length calculation using batch size

### DIFF
--- a/data_generator/data_generator.py
+++ b/data_generator/data_generator.py
@@ -63,7 +63,7 @@ class COCODataLoader(Sequence):
             np.random.shuffle(self.images_descriptions)
 
     def __len__(self):
-        return int(np.ceil(len(self.images_ids) / float(self.batch_size)))
+        return len(self.images_ids)
 
     def __getitem__(self, index):
         images = []


### PR DESCRIPTION
Remove previous length calculation with batch size, now returns only raw dataset length now.